### PR TITLE
Defaults for nested fields

### DIFF
--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -55,7 +55,7 @@ describe('mongooseLeanDefaults', () => {
   let User
 
   beforeAll(async done => {
-    await mongoose.connect(MONGO_URI, { useNewUrlParser: true })
+    await mongoose.connect(MONGO_URI, { useNewUrlParser: true, useUnifiedTopology: true })
     const oldSchema = new mongoose.Schema({
       name: String,
       oldNullableObj: mongoose.Schema.Types.Mixed,

--- a/index.js
+++ b/index.js
@@ -60,9 +60,10 @@ function attachDefaults(schema, res) {
     const defaults = []
     schema.eachPath(function (pathname, schemaType) {
       if (projectionInclude !== null) {
-        if (projectionInclude && !projectedFields.includes(pathname)) {
+        let included = projectedFields.some(path => pathname.indexOf(path) === 0)
+        if (projectionInclude && !included) {
           return
-        } else if (!projectionInclude && projectedFields.includes(pathname)) {
+        } else if (!projectionInclude && included) {
           return
         }
       }


### PR DESCRIPTION
Added the ability to return defaults of fields which are nested inside projected object.

```js
// Example Schema
const UserSchema = {
    name: { type: String },
    position: {
        x: { type: Number, default: 0 }
    }
}

// Example Document in the MongoDB
{ name: 'Foo' }

//Example query
User.findOne({ id }, { position: 1 })

// Result before PR (because, it requires explicit description => { 'position.x': 1} )
{ name: 'Foo' }

//Result after PR
{ name: 'Foo', position: { x: 0 } }
```