### PR TITLE
fix: handle `$slice` and `$elemMatch` projections

### DIFF
--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -179,6 +179,15 @@ describe('mongooseLeanDefaults', () => {
     expect(exclusionBob.nested).toBeDefined()
     expect(exclusionBob.nested.prop).toBeUndefined()
     expect(exclusionBob.nested.other).toBe(true)
+
+    const elemMatchBob = await User
+      .findById(bobId, {
+        'aliases': { $slice: 1 }
+      })
+      .lean({ defaults: true })
+    expect(elemMatchBob.name).toBe('Bob')
+    expect(elemMatchBob.country).toBe('USA')
+    expect(elemMatchBob.aliases).toStrictEqual([])
   })
 
   afterAll(async done => {

--- a/index.js
+++ b/index.js
@@ -51,10 +51,14 @@ function attachDefaults(schema, res) {
   if (this._mongooseOptions.lean && this._mongooseOptions.lean.defaults) {
     const projection = this.projection() || {}
 
-    const projectedFields = Object.keys(projection).filter(field => field !== '_id')
     let projectionInclude = null
+    const projectedFields = Object.keys(projection).filter(field => field !== '_id')
     if (projectedFields.length > 0) {
-      projectionInclude = projection[projectedFields[0]] === 1
+      const definingProjection = projectedFields
+        .find(prop => projection[prop] != null && typeof projection[prop] !== 'object')
+      if (definingProjection != null) {
+        projectionInclude = !!projection[definingProjection]
+      }
     }
 
     const defaults = []


### PR DESCRIPTION
Found a small issue with this plugin - it skips applying array defaults if the user uses a projection with [`$slice`](https://docs.mongodb.com/manual/reference/operator/projection/slice/) or `$elemMatch`. For example:

```javascript
const mongoose = require('mongoose');
const { Schema } = mongoose;
const assert = require('assert');

const leanDefaults = require('mongoose-lean-defaults');

mongoose.plugin(leanDefaults);

run().catch(console.error);

async function run() {
  await mongoose.connect('mongodb://localhost:27017/test', {
    useNewUrlParser: true,
    useUnifiedTopology: true
  });

  await mongoose.connection.dropDatabase();

  const userSchema = new Schema({ friends: [{ name: String }] });

  const User = mongoose.model('User', userSchema);

  const createdUser = await User.create({ friends: [{ name: 'A' }, { name: 'B' }] });

  const user = await User.findOne({ _id: createdUser._id }).select({
    friends: { $elemMatch: { name: 'I do not exist' } }
  }).lean({ defaults: true });

  // Fails without this PR
  assert.deepEqual(user.friends, []);

  console.log('All assertions passed.');
}
```

On a related note, this plugin also assumes that projections should be either 1 or 0, which is also not quite correct. `User.findOne({}, { 'aliases': true })` should be `User.findOne({}, { 'aliases': 1 })`, this PR also makes that work.

Re: Automattic/mongoose#9149