### PR TITLE
refactor(plugin): use Array#forEach(...) instead of Array#map(...)

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,8 +7,8 @@ const mpath = require('mpath')
 module.exports = function mongooseLeanDefaults(schema) {
   const fn = attachDefaultsMiddleware(schema)
   schema.pre('find', function () {
-    if (typeof this.map === 'function') {
-      this.map((res) => {
+    if (typeof this.forEach === 'function') {
+      this.forEach((res) => {
         fn.call(this, res)
         return res
       })

--- a/index.js
+++ b/index.js
@@ -10,7 +10,6 @@ module.exports = function mongooseLeanDefaults(schema) {
     if (typeof this.forEach === 'function') {
       this.forEach((res) => {
         fn.call(this, res)
-        return res
       })
     } else {
       this.options.transform = (res) => {


### PR DESCRIPTION
`Array#map(...)` returns an array that we're not using, `forEach` would save the memory from the unnecessary returned array.