### PR TITLE
Mention global plugin options in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,7 @@ const bob = await UserModel.findOne().lean({ defaults: true });
  * }
  */
 ```
+
+// You can alternatively set a global default when initializing the plugin
+
+updatedUserSchema.plugin(mongooseLeanDefaults, { defaults: true });


### PR DESCRIPTION
The global default is a useful option, but I didn't realize it existed at first. It's worth mentioning in the README. Thanks!