### PR TITLE
Align default subdocument behavior with Mongoose

### DIFF
--- a/src/__tests__/issues/30.spec.ts
+++ b/src/__tests__/issues/30.spec.ts
@@ -10,6 +10,7 @@ interface SubSchema {
 
 interface MySchema {
   sub?: SubSchema | null;
+  sub2?: SubSchema | null;
 }
 
 const SubSchema = new mongoose.Schema({ a: String });
@@ -19,6 +20,9 @@ const MySchema = new mongoose.Schema(
     sub: {
       type: SubSchema,
       default: undefined,
+    },
+    sub2: {
+      type: SubSchema,
     },
   },
   {
@@ -47,5 +51,6 @@ describe('Issue #30', () => {
     await MyModel.collection.insertOne({});
     const result = await MyModel.findOne({}).lean().exec();
     expect(result?.sub).toBeUndefined();
+    expect(result?.sub2).toBeUndefined();
   });
 });

--- a/src/__tests__/issues/30.spec.ts
+++ b/src/__tests__/issues/30.spec.ts
@@ -26,7 +26,7 @@ const MySchema = new mongoose.Schema(
     },
   },
   {
-    collection: 'issues_28',
+    collection: 'issues_30',
   },
 );
 


### PR DESCRIPTION
Mongoose sets subdocument defaults to `undefined` ([docs](https://mongoosejs.com/docs/subdocs.html#subdocument-defaults)). This changes the behavior of `mongoose-lean-defaults` to match.

Previously, it returned a new object (`{}`) which may have been given a newly generated Object ID (depending on if the schema for the subdocument set `_id: false`). 

This is an example of how we might change the behavior of this plugin to fix https://github.com/DouglasGabr/mongoose-lean-defaults/issues/32. It is a change in behavior so it should be considered a breaking change, but it better aligns this plugin with Mongoose itself so you can switch between lean and hydrated queries with greater ease.