### PR TITLE
[Optimization]: Only loop through paths that need defaulting

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "test": "jest",
     "dev": "jest --watchAll",
-    "build": "tsc --project tsconfig.build.json"
+    "build": "tsc --project tsconfig.build.json",
+    "bench": "tsc --project tsconfig.json && node dist/bench/index.js"
   },
   "repository": {
     "type": "git",

--- a/src/bench/default10k.ts
+++ b/src/bench/default10k.ts
@@ -1,0 +1,73 @@
+import mongoose from 'mongoose';
+import { attachDefaults } from '../index';
+import { performance } from 'perf_hooks';
+
+export function benchDefault10k() {
+  const Schema = new mongoose.Schema(
+    {
+      prop1: { type: String, default: 'prop1' },
+      prop2: {
+        nestedProp1: {
+          type: String,
+          default: 'nestedProp1',
+        },
+        nestedProp2: {
+          type: Boolean,
+          default: true,
+        },
+        nestedProp3: String,
+      },
+      // Implementation should not traverse all of the below properties when applying defaults
+      prop3: [
+        {
+          _id: false,
+          nestedProp1: String,
+          nestedProp2: Boolean,
+          nestedProp3: Number,
+          nestedProp4: String,
+        },
+      ],
+      prop4: Number,
+      prop5: String,
+      prop6: Boolean,
+      prop7: String,
+      prop8: String,
+      prop9: String,
+      prop10: String,
+      prop11: String,
+      prop12: String,
+      prop13: String,
+      prop14: String,
+      prop15: String,
+    },
+    { collection: 'bench' },
+  );
+
+  const Model = mongoose.model('Model', Schema);
+
+  function makeData(count: number) {
+    return Array.from({ length: count }, () => ({
+      _id: new mongoose.Types.ObjectId(),
+      prop3: [
+        Array.from({ length: 10 }, () => ({
+          nestedProp1: 'nestedProp1',
+        })),
+      ],
+    }));
+  }
+
+  const query = Model.find().lean({ defaults: true });
+
+  // Warmup 5x
+  for (let i = 0; i < 5; i++) {
+    attachDefaults.call(query, Schema, makeData(10000));
+  }
+
+  // Run
+  const data = makeData(10000);
+  const start = performance.now();
+  attachDefaults.call(query, Schema, data);
+  const end = performance.now();
+
+  console.log(`default10k: applying defaults took ${end - start} ms`);
+}

--- a/src/bench/default10k.ts
+++ b/src/bench/default10k.ts
@@ -48,11 +48,9 @@ export function benchDefault10k() {
   function makeData(count: number) {
     return Array.from({ length: count }, () => ({
       _id: new mongoose.Types.ObjectId(),
-      prop3: [
-        Array.from({ length: 10 }, () => ({
-          nestedProp1: 'nestedProp1',
-        })),
-      ],
+      prop3: Array.from({ length: 10 }, () => ({
+        nestedProp1: 'nestedProp1',
+      })),
     }));
   }
 

--- a/src/bench/index.ts
+++ b/src/bench/index.ts
@@ -1,0 +1,2 @@
+import { benchDefault10k } from './default10k';
+benchDefault10k();

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ function attachDefaultsMiddleware(
   };
 }
 
-function attachDefaults(
+export function attachDefaults(
   this: Query<unknown, Document>,
   schema: Schema,
   res: unknown,

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ interface Default {
   pathSegments: string[];
 }
 
-const DEFAULTS_REGISTRY = new Map<Schema, Default[]>();
+const DEFAULTS_REGISTRY = new WeakMap<Schema, Default[]>();
 
 export default function mongooseLeanDefaults(
   schema: Schema<any, any, any, any>,

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["./src/__tests__/**/*.ts"]
+  "exclude": ["./src/__tests__/**/*.ts", "./src/bench/**/*.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,10 @@
     "forceConsistentCasingInFileNames": true,
     "removeComments": true
   },
-  "include": ["./types.d.ts", "./src/index.ts", "./src/__tests__/**/*.ts"]
+  "include": [
+    "./types.d.ts",
+    "./src/index.ts",
+    "./src/__tests__/**/*.ts",
+    "./src/bench/**/*.ts"
+  ]
 }


### PR DESCRIPTION
## Description

Hey @DouglasGabr, thanks for the plugin! I've been using it in combination with `mongoose-lean-virtuals` to avoid the cost of hydrating documents while still getting a json shape that closely resembles a hydrated doc. 

After profiling with more data I noticed that defaulting was taking a bit longer than I expected, so I decided to take a closer look and saw that it was looping through all schema paths per doc. I figured that it could be sped up a bit by just keeping track of what paths have defaults and only traversing those.

This change is trying to preserve the exact behaviour that this plugin had before and is not addressing any of the open issues.

## Benchmark
I added a benchmark that attaches defaults to 10000 docs with a schema that only has a couple of paths defaulted. One of the biggest speedups comes from the fact that arrays in child schemas can be fully skipped if they do not have defaults.

**Before ~30ms**
![Screenshot 2025-07-08 at 9 09 32 PM](https://github.com/user-attachments/assets/d8801ef8-d37a-4021-ab6a-7401eac9cbd3)

**After <1ms**
![Screenshot 2025-07-08 at 9 10 46 PM](https://github.com/user-attachments/assets/9a84b208-3c82-45dc-bb87-004fec437d2f)


You can run the benchmark on the previous implementation by just removing my latest commit.